### PR TITLE
Restrict konnector clusterrole and dynamically provision RBAC per binding

### DIFF
--- a/backend/kubernetes/resources/konnector.go
+++ b/backend/kubernetes/resources/konnector.go
@@ -60,19 +60,33 @@ func NewKonnectorManifests(konnectorImage string, hostAliases []corev1.HostAlias
 				Namespace: KonnectorNamespace,
 			},
 		},
-		// Broad access is required because the konnector dynamically manages CRDs
-		// and syncs arbitrary resource types discovered from the provider. Scoping
-		// down would require knowing the bound resource types in advance, which
-		// defeats the auto-discovery model.
+		// The konnector dynamically manages CRDs and syncs arbitrary resource types.
+		// Wildcard permissions are no longer used here; instead, the kubectl bind
+		// CLI dynamically creates RBAC for the bound custom resources.
 		ClusterRole: &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: KonnectorClusterRoleName,
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
-					APIGroups: []string{"*"},
-					Resources: []string{"*"},
-					Verbs:     []string{"*"},
+					APIGroups: []string{""},
+					Resources: []string{"namespaces", "secrets", "events", "serviceaccounts", "configmaps"},
+					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+				},
+				{
+					APIGroups: []string{"kube-bind.io"},
+					Resources: []string{"apiservicebindings", "apiservicebindings/status", "clusterbindings", "clusterbindings/status", "servicebindings", "servicebindings/status", "serviceexports", "serviceexports/status"},
+					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+				},
+				{
+					APIGroups: []string{"apiextensions.k8s.io"},
+					Resources: []string{"customresourcedefinitions"},
+					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+				},
+				{
+					APIGroups: []string{"coordination.k8s.io"},
+					Resources: []string{"leases"},
+					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 				},
 			},
 		},

--- a/cli/pkg/kubectl/bind-apiservice/plugin/deploy_konnector.go
+++ b/cli/pkg/kubectl/bind-apiservice/plugin/deploy_konnector.go
@@ -108,9 +108,24 @@ func getKonnectorClusterRole() *rbacv1.ClusterRole {
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
-				APIGroups: []string{"*"},
-				Resources: []string{"*"},
-				Verbs:     []string{"*"},
+				APIGroups: []string{""},
+				Resources: []string{"namespaces", "secrets", "events", "serviceaccounts", "configmaps"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			},
+			{
+				APIGroups: []string{"kube-bind.io"},
+				Resources: []string{"apiservicebindings", "apiservicebindings/status", "clusterbindings", "clusterbindings/status", "servicebindings", "servicebindings/status", "serviceexports", "serviceexports/status"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			},
+			{
+				APIGroups: []string{"apiextensions.k8s.io"},
+				Resources: []string{"customresourcedefinitions"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			},
+			{
+				APIGroups: []string{"coordination.k8s.io"},
+				Resources: []string{"leases"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 			},
 		},
 	}

--- a/cli/pkg/kubectl/bind-apiservice/plugin/rbac.go
+++ b/cli/pkg/kubectl/bind-apiservice/plugin/rbac.go
@@ -1,0 +1,110 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+
+	kubebindv1alpha2 "github.com/kube-bind/kube-bind/sdk/apis/kubebind/v1alpha2"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+func ensureKonnectorDynamicRBAC(ctx context.Context, config *rest.Config, binding *kubebindv1alpha2.APIServiceBinding, request *kubebindv1alpha2.APIServiceExportRequest) error {
+	kubeClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	roleName := fmt.Sprintf("kube-bind-konnector-%s", binding.Name)
+	ownerRef := metav1.OwnerReference{
+		APIVersion: kubebindv1alpha2.SchemeGroupVersion.String(),
+		Kind:       "APIServiceBinding",
+		Name:       binding.Name,
+		UID:        binding.UID,
+	}
+
+	var rules []rbacv1.PolicyRule
+	for _, res := range request.Spec.Resources {
+		rules = append(rules, rbacv1.PolicyRule{
+			APIGroups: []string{res.Group},
+			Resources: []string{res.Resource, res.Resource + "/status"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+		})
+	}
+	for _, claim := range request.Spec.PermissionClaims {
+		rules = append(rules, rbacv1.PolicyRule{
+			APIGroups: []string{claim.Group},
+			Resources: []string{claim.Resource, claim.Resource + "/status"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+		})
+	}
+
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: roleName,
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+		Rules: rules,
+	}
+
+	_, err = kubeClient.RbacV1().ClusterRoles().Create(ctx, clusterRole, metav1.CreateOptions{})
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			existing, err := kubeClient.RbacV1().ClusterRoles().Get(ctx, roleName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			existing.Rules = rules
+			existing.OwnerReferences = []metav1.OwnerReference{ownerRef}
+			_, err = kubeClient.RbacV1().ClusterRoles().Update(ctx, existing, metav1.UpdateOptions{})
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: roleName,
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     roleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      KonnectorServiceAccount,
+				Namespace: KonnectorNamespace,
+			},
+		},
+	}
+
+	_, err = kubeClient.RbacV1().ClusterRoleBindings().Create(ctx, clusterRoleBinding, metav1.CreateOptions{})
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			existing, err := kubeClient.RbacV1().ClusterRoleBindings().Get(ctx, roleName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			existing.RoleRef = clusterRoleBinding.RoleRef
+			existing.Subjects = clusterRoleBinding.Subjects
+			existing.OwnerReferences = []metav1.OwnerReference{ownerRef}
+			_, err = kubeClient.RbacV1().ClusterRoleBindings().Update(ctx, existing, metav1.UpdateOptions{})
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cli/pkg/kubectl/bind-apiservice/plugin/servicebindings.go
+++ b/cli/pkg/kubectl/bind-apiservice/plugin/servicebindings.go
@@ -68,6 +68,11 @@ func (b *BindAPIServiceOptions) createAPIServiceBindings(ctx context.Context, co
 			}
 		}
 
+		// Ensure dynamic RBAC is created for the konnector to access the bound resources
+		if err := ensureKonnectorDynamicRBAC(ctx, config, existing, request); err != nil {
+			return nil, fmt.Errorf("failed to create dynamic RBAC for konnector: %w", err)
+		}
+
 		return []*kubebindv1alpha2.APIServiceBinding{existing}, nil
 	}
 
@@ -104,6 +109,11 @@ func (b *BindAPIServiceOptions) createAPIServiceBindings(ctx context.Context, co
 		return true, nil
 	}); err != nil {
 		return nil, err
+	}
+
+	// Ensure dynamic RBAC is created for the konnector to access the bound resources
+	if err := ensureKonnectorDynamicRBAC(ctx, config, created, request); err != nil {
+		return nil, fmt.Errorf("failed to create dynamic RBAC for konnector: %w", err)
 	}
 
 	fmt.Fprintf(b.Options.IOStreams.ErrOut, "✅ Created APIServiceBinding %s for %d resources\n", bindingName, len(request.Spec.Resources))


### PR DESCRIPTION
Fixes #303

## What changed?
This PR removes the cluster-admin wildcard (*) access from the `kube-bind-konnector`and introduces a dynamic RBAC generation model.

Previously, the konnector required apiGroups: "*" to sync arbitrary custom resources (e.g. `mangodbs.foo.bar`). Now:

- Base Permissions Restricted: The konnector's static `ClusterRole` (in both the CLI and Backend manifests) is strictly scoped to the absolute minimum it needs to function (core infrastructure, `kube-bind` CRDs, leases, etc.).
- Dynamic RBAC Generation: When a consumer executes `kubectl` bind, the CLI intercepts the APIServiceExportRequest and dynamically generates a highly specific ClusterRole granting access only to the exact API Groups and Resources being bound.
- Automatic Cleanup: The dynamic RBAC objects are tied to the APIServiceBinding using OwnerReferences. Deleting the binding automatically revokes the konnector's permissions.

## Testing & Validation

-  Compiled successfully: make build completes with no errors.
```bash
alokkumardalei@Aloks-MacBook-Air kbind % make build
hack/verify-go-versions.sh
Verifying minimum Go version: 1.26.2
Verifying build Go version: 1.26.2
+ cd ./cmd/
+ go build '-ldflags=-X k8s.io/client-go/pkg/version.gitCommit=d7f16bc -X k8s.io/client-go/pkg/version.gitTreeState=clean -X k8s.io/client-go/pkg/version.gitVersion=v1.36.0+kube-bind-v0.0.0-d7f16bc -X k8s.io/client-go/pkg/version.gitMajor=1 -X k8s.io/client-go/pkg/version.gitMinor=36 -X k8s.io/client-go/pkg/version.buildDate=2026-07-17T15:02:08Z -X k8s.io/component-base/version.gitCommit=d7f16bc -X k8s.io/component-base/version.gitTreeState=clean -X k8s.io/component-base/version.gitVersion=v1.36.0+kube-bind-v0.0.0-d7f16bc -X k8s.io/component-base/version.gitMajor=1 -X k8s.io/component-base/version.gitMinor=36 -X k8s.io/component-base/version.buildDate=2026-07-17T15:02:08Z' -o /Users/alokkumardalei/Desktop/kbind/kbind/bin/ ./...
+ cd ./cli/cmd/
+ go build '-ldflags=-X k8s.io/client-go/pkg/version.gitCommit=d7f16bc -X k8s.io/client-go/pkg/version.gitTreeState=clean -X k8s.io/client-go/pkg/version.gitVersion=v1.36.0+kube-bind-v0.0.0-d7f16bc -X k8s.io/client-go/pkg/version.gitMajor=1 -X k8s.io/client-go/pkg/version.gitMinor=36 -X k8s.io/client-go/pkg/version.buildDate=2026-07-17T15:02:08Z -X k8s.io/component-base/version.gitCommit=d7f16bc -X k8s.io/component-base/version.gitTreeState=clean -X k8s.io/component-base/version.gitVersion=v1.36.0+kube-bind-v0.0.0-d7f16bc -X k8s.io/component-base/version.gitMajor=1 -X k8s.io/component-base/version.gitMinor=36 -X k8s.io/component-base/version.buildDate=2026-07-17T15:02:08Z' -o /Users/alokkumardalei/Desktop/kbind/kbind/bin/ ./...
+ cd ./contrib/kcp/cmd/kcp-init/
+ go build '-ldflags=-X k8s.io/client-go/pkg/version.gitCommit=d7f16bc -X k8s.io/client-go/pkg/version.gitTreeState=clean -X k8s.io/client-go/pkg/version.gitVersion=v1.36.0+kube-bind-v0.0.0-d7f16bc -X k8s.io/client-go/pkg/version.gitMajor=1 -X k8s.io/client-go/pkg/version.gitMinor=36 -X k8s.io/client-go/pkg/version.buildDate=2026-07-17T15:02:08Z -X k8s.io/component-base/version.gitCommit=d7f16bc -X k8s.io/component-base/version.gitTreeState=clean -X k8s.io/component-base/version.gitVersion=v1.36.0+kube-bind-v0.0.0-d7f16bc -X k8s.io/component-base/version.gitMajor=1 -X k8s.io/component-base/version.gitMinor=36 -X k8s.io/component-base/version.buildDate=2026-07-17T15:02:08Z' -o /Users/alokkumardalei/Desktop/kbind/kbind/bin/ ./...
```
-  Static Permissions Audit: Verified the base ClusterRole in `cli/pkg/kubectl/bind-apiservice/plugin/deploy_konnector.go` and `backend/kubernetes/resources/konnector.go` now explicitly whitelists "", `kube-bind.io`, `apiextensions.k8s.io`, and `coordination.k8s.io` rather than using wildcards.
-  Dynamic Generation: Verified that `cli/pkg/kubectl/bind-apiservice/plugin/rbac.go` correctly iterates over `request.Spec.Resources` and `request.Spec.PermissionClaims` to construct the RBAC policy when a binding is created.