### PR TITLE
Fix image registry base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ENVTEST_K8S_VERSION ?= 1.34.1
 SETUP_ENVTEST  ?= go run sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.21
 CHART ?= deploy/charts/konnector-v2
 BACKEND_CHART ?= deploy/charts/backend-v2
-IMAGE ?= ghcr.io/kbind/konnector:dev
+IMAGE ?= ghcr.io/kbind-dev/konnector:dev
 
 .PHONY: all
 all: codegen build
@@ -54,7 +54,7 @@ cli-snapshot:
 image:
 	docker build -t $(IMAGE) .
 
-BACKEND_IMAGE ?= ghcr.io/kbind/backend:dev
+BACKEND_IMAGE ?= ghcr.io/kbind-dev/backend:dev
 .PHONY: image-backend
 image-backend:
 	docker build --target backend -t $(BACKEND_IMAGE) .
@@ -161,7 +161,6 @@ HELM ?= helm
 HELM_REPO ?= ghcr.io/kbind-dev/charts
 VERSION ?= 0.0.0-dev
 CHART_VERSION ?= $(VERSION)
-IMAGE_VERSION ?= $(VERSION)
 HELM_CHARTS ?= konnector-v2 backend-v2
 
 ## helm-push: Package and push Helm charts to $(HELM_REPO) as OCI artifacts

--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,7 @@ HELM ?= helm
 HELM_REPO ?= ghcr.io/kbind-dev/charts
 VERSION ?= 0.0.0-dev
 CHART_VERSION ?= $(VERSION)
+IMAGE_VERSION ?= v$(VERSION)
 HELM_CHARTS ?= konnector-v2 backend-v2
 
 ## helm-push: Package and push Helm charts to $(HELM_REPO) as OCI artifacts

--- a/README.md
+++ b/README.md
@@ -194,10 +194,10 @@ The konnector runs in (or against) the **consumer** cluster — it is the only
 running component of the core (no backend, no provider-side controllers).
 
 ```sh
-make image IMAGE=ghcr.io/kbind/konnector:dev          # build the image
+make image IMAGE=ghcr.io/kbind-dev/konnector:dev          # build the image
 helm install konnector deploy/charts/konnector \
   -n kbind --create-namespace \
-  --set image.repository=ghcr.io/kbind/konnector --set image.tag=dev
+  --set image.repository=ghcr.io/kbind-dev/konnector --set image.tag=dev
 ```
 
 The chart ([deploy/charts/konnector](deploy/charts/konnector)) ships the core
@@ -220,7 +220,7 @@ The **backend** deploys on the provider with its own chart
 ([deploy/charts/backend](deploy/charts/backend)):
 
 ```sh
-make image-backend BACKEND_IMAGE=ghcr.io/kbind/backend:dev
+make image-backend BACKEND_IMAGE=ghcr.io/kbind-dev/backend:dev
 helm install backend deploy/charts/backend \
   -n kbind-system --create-namespace \
   --set externalURL=https://kbind.example.com \

--- a/deploy/charts/backend-v2/values.yaml
+++ b/deploy/charts/backend-v2/values.yaml
@@ -2,7 +2,7 @@
 # **provider** cluster.
 
 image:
-  repository: ghcr.io/kbind/backend
+  repository: ghcr.io/kbind-dev/backend
   # Defaults to the chart appVersion when empty.
   tag: ""
   pullPolicy: IfNotPresent

--- a/deploy/charts/konnector-v2/values.yaml
+++ b/deploy/charts/konnector-v2/values.yaml
@@ -1,7 +1,7 @@
 # Default values for the konnector chart.
 
 image:
-  repository: ghcr.io/kbind/konnector
+  repository: ghcr.io/kbind-dev/konnector
   # Defaults to the chart appVersion when empty.
   tag: ""
   pullPolicy: IfNotPresent

--- a/hack/tilt/Tiltfile
+++ b/hack/tilt/Tiltfile
@@ -21,7 +21,7 @@ if k8s_context() != 'kind-kbind-provider':
 # ---------------------------------------------------------------- provider --
 
 docker_build(
-    'ghcr.io/kbind/backend',
+    'ghcr.io/kbind-dev/backend',
     '../..',
     dockerfile='../../Dockerfile',
     target='backend',
@@ -75,8 +75,8 @@ local_resource(
 local_resource(
     'konnector-image',
     cmd=' && '.join([
-        'docker build --target konnector -t ghcr.io/kbind/konnector:tilt ../..',
-        'kind load docker-image ghcr.io/kbind/konnector:tilt --name kbind-consumer',
+        'docker build --target konnector -t ghcr.io/kbind-dev/konnector:tilt ../..',
+        'kind load docker-image ghcr.io/kbind-dev/konnector:tilt --name kbind-consumer',
     ]),
     deps=['../../cmd/konnector', '../../engine', '../../sdk/apis', '../../go.mod'],
     labels=['consumer'],
@@ -87,7 +87,7 @@ local_resource(
     cmd=' && '.join([
         'helm upgrade --install konnector ../../deploy/charts/konnector'
         + ' --kube-context kind-kbind-consumer --namespace kbind --create-namespace'
-        + ' --set image.repository=ghcr.io/kbind/konnector --set image.tag=tilt',
+        + ' --set image.repository=ghcr.io/kbind-dev/konnector --set image.tag=tilt',
         'kubectl --context kind-kbind-consumer -n kbind rollout restart deployment/konnector',
         'kubectl --context kind-kbind-consumer -n kbind rollout status deployment/konnector --timeout=120s',
     ]),

--- a/pkg/konnectorinstall/install.go
+++ b/pkg/konnectorinstall/install.go
@@ -39,7 +39,7 @@ import (
 var manifests embed.FS
 
 // DefaultImage is the konnector image installed when none is specified.
-const DefaultImage = "ghcr.io/kbind/konnector:latest"
+const DefaultImage = "ghcr.io/kbind-dev/konnector:latest"
 
 // Manifests returns the full konnector install (CRDs first, then namespace,
 // RBAC and Deployment) as one YAML multi-doc with the image resolved.


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This PR fixes the image registry base to `ghcr.io/kbind-dev`. `ghcr.io/kbind` doesn't exist.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind bug

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
