### PR TITLE
re-enable parallel kcp tests

### DIFF
--- a/contrib/kcp/test/e2e/kcp_test.go
+++ b/contrib/kcp/test/e2e/kcp_test.go
@@ -41,17 +41,13 @@ import (
 	"github.com/kube-bind/kube-bind/test/e2e/framework"
 )
 
-// TODO: Parallelizm is disabled due to bind-login overlapping server usage
-// We need to refactor config machienery to allow multiple servers to be used in parallel tests
-// https://github.com/kube-bind/kube-bind/issues/361
-
 func TestKCPClusterScope(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	testKcpIntegration(t, "cc", kubebindv1alpha2.ClusterScope)
 }
 
 func TestKCPNamespacedScope(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	testKcpIntegration(t, "nc", kubebindv1alpha2.NamespacedScope)
 }
 


### PR DESCRIPTION
## Summary
In #351 we alledgedly introduced issues that made parallel e2e tests not work anymore. However I could not find any issues in the original merge commit, nor on the current main branch. Hence this PR simply re-enables them.

## What Type of PR Is This?
/kind cleanup

## Related Issue(s)
Fixes #361

## Release Notes
```release-note
NONE
```
